### PR TITLE
feat: Make products optional and add units of measure

### DIFF
--- a/src/models/init.model.js
+++ b/src/models/init.model.js
@@ -2,6 +2,7 @@ import { AisleService } from "../services/aisle.service.js";
 import { AuthStaffService } from "../services/auth-staff.services.js";
 import { RolService } from "../services/rol.services.js";
 import { TypeService } from "../services/type.service.js";
+import { UnitOfMeasureService } from "../services/unit_of_measure.service.js";
 
 import { Aisle } from "./aisle.model.js";
 import { Basket } from "./basket.model.js";
@@ -20,6 +21,7 @@ import { StaffCredential } from "./staff-credentials.models.js";
 import { Staff } from "./staff.model.js";
 import { Type } from "./type.model.js";
 import { Order_Staff } from "./order_staff.model.js";
+import { UnitOfMeasure } from "./unit_of_measure.model.js";
 
 import { initialData } from "../utils/inital-data.js";
 import { Administration } from "./administration.model.js";
@@ -39,6 +41,7 @@ export const initORM = async () => {
   await Shelve.sync({ alter: true });
   await Level.sync({ alter: true });
   await Type.sync({ alter: true });
+  await UnitOfMeasure.sync({ alter: true });
   await Products.sync({ alter: true });
   await Products_Type.sync({ alter: true });
   await Basket.sync({ alter: true });
@@ -55,6 +58,7 @@ export const initORM = async () => {
   await AuthStaffService.createAuthStaffDefault();
   await AisleService.createData();
   await TypeService.createTypes();
+  await UnitOfMeasureService.createUnitsOfMeasure();
   await initialData.createOrderData();
   await initialData.createDefaultBaskets();
   await initialData.createDefaultAdministrations();

--- a/src/models/product.model.js
+++ b/src/models/product.model.js
@@ -1,5 +1,6 @@
 import sequelize from "../utils/config-mysql.js";
 import { DataTypes, Model } from "sequelize";
+import { UnitOfMeasure } from "./unit_of_measure.model.js";
 
 export class Products extends Model {}
 
@@ -12,7 +13,6 @@ Products.init(
     },
     name: {
       type: DataTypes.STRING(45),
-      unique: true,
       allowNull: false,
     },
     image: {
@@ -25,3 +25,8 @@ Products.init(
     modelName: "Products",
   }
 );
+
+Products.belongsTo(UnitOfMeasure, {
+  foreignKey: "unitOfMeasureId",
+  as: "unitOfMeasure",
+});

--- a/src/models/unit_of_measure.model.js
+++ b/src/models/unit_of_measure.model.js
@@ -1,0 +1,24 @@
+import sequelize from "../utils/config-mysql.js";
+import { DataTypes, Model } from "sequelize";
+
+export class UnitOfMeasure extends Model {}
+
+UnitOfMeasure.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    name: {
+      type: DataTypes.STRING(45),
+      unique: true,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: "UnitOfMeasure",
+    tableName: "units_of_measure",
+  }
+);

--- a/src/schemas/order.schema.js
+++ b/src/schemas/order.schema.js
@@ -7,12 +7,14 @@ const orderSchema = z.object({
 
 const orderCompleteSchema = z.object({
   email: z.string().email(),
-  products: z.array(
-    z.object({
-      productId: z.string(),
-      weight: z.number().int().positive(),
-    })
-  ),
+  products: z
+    .array(
+      z.object({
+        productId: z.string(),
+        weight: z.number().int().positive(),
+      })
+    )
+    .optional(),
   addressId: z.string(),
 });
 

--- a/src/services/unit_of_measure.service.js
+++ b/src/services/unit_of_measure.service.js
@@ -1,0 +1,21 @@
+import { UnitOfMeasure } from "../models/unit_of_measure.model.js";
+
+const unitsOfMeasure = [
+  { name: "kg" },
+  { name: "g" },
+  { name: "L" },
+  { name: "ml" },
+  { name: "units" },
+];
+
+export class UnitOfMeasureService {
+  static async createUnitsOfMeasure() {
+    try {
+      for (const unit of unitsOfMeasure) {
+        await UnitOfMeasure.findOrCreate({ where: { name: unit.name } });
+      }
+    } catch (error) {
+      throw new Error(`Error creating units of measure: ${error.message}`);
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces several changes to the API to accommodate new client requirements.

- Products are now optional when creating an order.
- A new `units_of_measure` table has been created to store units of measure for products.
- Products are no longer dependent on inventory.
- Products now have a reference to a unit of measure.